### PR TITLE
Add workflow badge and workflow trigger event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
   schedule:
     # “Weekly on Saturday at 00:00 UTC”
     - cron: "0 0 * * 6"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # CICD_template
+
+[![CI - Lint and Test](https://github.com/nicklamiller/CICD_template/actions/workflows/ci.yml/badge.svg)](https://github.com/nicklamiller/CICD_template/actions/workflows/ci.yml)
+
 A template for ci/cd development


### PR DESCRIPTION
- Adds a workflow badge for the CI workflow in the README
- Allows manually running CI workflow in GH UI via `workflow_dispatch`